### PR TITLE
fix: restore Nixpacks build compatibility after upstream sync

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -8,8 +8,8 @@ providers = ["node"]
 nixPkgs = ["nodejs_20", "pnpm"]
 
 [variables]
-NODE_ENV = "production"
 NEXT_TELEMETRY_DISABLED = "1"
+HUSKY = "0"
 
 [phases.install]
 dependsOn = ["setup"]
@@ -27,4 +27,4 @@ cmds = [
 
 [start]
 # Bind to 0.0.0.0 and use Dokploy-provided $PORT
-cmd = "pnpm run start -- -H 0.0.0.0 -p ${PORT:-3000}"
+cmd = "NODE_ENV=production pnpm run start -- -H 0.0.0.0 -p ${PORT:-3000}"


### PR DESCRIPTION
Two upstream changes broke the Nixpacks build on Dokploy:

1. NODE_ENV=production was set globally, causing pnpm to skip
   devDependencies during install. The build needs TypeScript,
   Tailwind, eslint-config-next, etc. which live in devDependencies.

2. The upstream added "prepare": "husky" to package.json. Husky's
   prepare hook fails in Nixpacks build containers which lack a
   proper git hooks environment.

Fix: remove NODE_ENV from global variables (devDeps now install
correctly), add HUSKY=0 to suppress the prepare hook, and move
NODE_ENV=production to only the start command where it matters.

https://claude.ai/code/session_01UexnxJf2naqbNGnaMn7NUs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration to adjust environment variable handling and build settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->